### PR TITLE
fix(docs): Enable automatic GitHub Pages setup in workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -35,6 +35,8 @@ jobs:
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
+        with:
+          enablement: true
 
       - name: Build with Jekyll
         run: |


### PR DESCRIPTION
## Summary
- Add `enablement: true` parameter to configure-pages action
- Prevents workflow failures when GitHub Pages is not yet enabled
- Automatically enables GitHub Pages if needed during deployment

## Problem
The documentation deployment workflow was failing with error:
```
Get Pages site failed. Please verify that the repository has Pages enabled
```

This happened when the workflow ran before GitHub Pages was manually enabled.

## Solution
Added the `enablement: true` parameter to the `actions/configure-pages@v5` step, which:
- Checks if GitHub Pages is enabled
- Automatically enables it if not
- Configures it to use GitHub Actions for builds

## Test plan
- [x] Local changes committed
- [ ] CI tests pass
- [ ] Workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)