### PR TITLE
fix(ci): exclude main packages from coverage testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Run tests
         # Note: -race flag removed due to false positives in Pulumi SDK
         # See: https://github.com/pulumi/pulumi/issues for known race conditions
-        run: go test -v -coverprofile=coverage.txt -covermode=atomic ./...
+        # Exclude main packages to avoid "go: no such tool covdata" warning
+        run: |
+          go test -v -coverprofile=coverage.txt -covermode=atomic $(go list ./... | grep -v -E '(^github.com/chalkan3/sloth-kubernetes$|/cmd/simple-wireguard-rke$)')
 
       - name: Generate coverage report
         run: go tool cover -func=coverage.txt


### PR DESCRIPTION
## Summary
- Excludes main packages (root and `cmd/simple-wireguard-rke`) from coverage testing
- Fixes "go: no such tool covdata" warnings that were causing test failures

## Context
Main packages in Go cannot have coverage data collected, which caused the CI to fail even though all tests passed.

## Test plan
- [ ] CI pipeline passes tests job
- [ ] CI pipeline passes lint job (already fixed in previous PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)